### PR TITLE
#959: Ensure multi-line string are enclosed in blockquotes

### DIFF
--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/DefaultGraphqlProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/DefaultGraphqlProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Michael Clarke
+ * Copyright (C) 2019-2024 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,7 +20,6 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
 
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
-import io.aexp.nodes.graphql.InputObject;
 import org.sonar.api.ce.ComputeEngineSide;
 import org.sonar.api.server.ServerSide;
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2023 Michael Clarke
+ * Copyright (C) 2020-2024 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,7 +29,6 @@ import io.aexp.nodes.graphql.Arguments;
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLResponseEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
-import io.aexp.nodes.graphql.InputObject;
 import io.aexp.nodes.graphql.internal.Error;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +89,7 @@ public class GraphqlGithubClient implements GithubClient {
         inputObjectArguments.put("completedAt", DATE_TIME_FORMATTER.format(checkRunDetails.getEndTime()));
         inputObjectArguments.put("externalId", checkRunDetails.getExternalId());
         inputObjectArguments.put("output", checkRunOutputContentBuilder.build());
+        inputObjectArguments.put("headSha", checkRunDetails.getCommitId());
 
         InputObject.Builder<Object> repositoryInputObjectBuilder = graphqlProvider.createInputObject();
         inputObjectArguments.forEach(repositoryInputObjectBuilder::put);
@@ -101,9 +101,7 @@ public class GraphqlGithubClient implements GithubClient {
                         .url(graphqlUrl)
                         .headers(headers)
                         .request(CreateCheckRun.class)
-                        .arguments(new Arguments("createCheckRun", new Argument<>(INPUT, repositoryInputObjectBuilder
-                                .put("headSha", checkRunDetails.getCommitId())
-                                .build())))
+                        .arguments(new Arguments("createCheckRun", new Argument<>(INPUT, repositoryInputObjectBuilder.build())))
                         .requestMethod(GraphQLTemplate.GraphQLMethod.MUTATE);
 
         GraphQLRequestEntity graphQLRequestEntity = graphQLRequestEntityBuilder.build();

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlProvider.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlProvider.java
@@ -20,7 +20,6 @@ package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
 
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
-import io.aexp.nodes.graphql.InputObject;
 
 public interface GraphqlProvider {
 

--- a/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/InputObject.java
+++ b/src/main/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/InputObject.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018-2024 American Express Travel Related Services Company, Inc, Michael Clarke
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.github.mc1arke.sonarqube.plugin.almclient.github.v4;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class InputObject<T> {
+    private final Map<String, T> map;
+
+    InputObject(Builder<T> builder) {
+        this.map = builder.map;
+    }
+
+    String getMessage() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("{");
+        for (Map.Entry<String, T> entry : map.entrySet()) {
+            if (stringBuilder.length() != 1) stringBuilder.append(",");
+            stringBuilder.append(formatGraphQLParameter(entry.getKey(), entry.getValue()));
+        }
+        stringBuilder.append("}");
+        return stringBuilder.toString();
+    }
+
+    @Override
+    public String toString() {
+        return getMessage();
+    }
+
+    public Map<String, T> getMap() {
+        return this.map;
+    }
+
+    public static class Builder<T> {
+
+        private final Map<String, T> map = new HashMap<>();
+
+        public Builder<T> put(String key, T value) {
+            this.map.put(key, value);
+            return this;
+        }
+
+        public InputObject<T> build() {
+            return new InputObject<>(this);
+        }
+    }
+
+
+    private static <T> String formatGraphQLParameter(String key, T value) {
+        StringBuilder stringBuilder = new StringBuilder();
+        Pattern pattern = Pattern.compile("^\\$");
+        Matcher matcher = pattern.matcher("" + value);
+        if (value instanceof String && ((String) value).contains("\n")) {
+            stringBuilder.append(key).append(":\"\"\"").append(value).append("\"\"\"");
+        } else if (value instanceof String && !matcher.find()) {
+            stringBuilder.append(key).append(":\"").append(value).append("\"");
+        } else if (value instanceof List) {
+            stringBuilder.append(key).append(":").append(formatGraphQLArgumentList((List<?>)value));
+        } else if (value instanceof com.github.mc1arke.sonarqube.plugin.almclient.github.v4.InputObject) {
+            stringBuilder.append(key).append(":").append(((com.github.mc1arke.sonarqube.plugin.almclient.github.v4.InputObject<?>)value).getMessage());
+        } else {
+            stringBuilder.append(key).append(":").append(value);
+        }
+
+        return stringBuilder.toString();
+    }
+
+    private static String formatGraphQLArgumentList(List<?> values) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("[");
+        Pattern p = Pattern.compile("^\\$");
+        for (Object value: values) {
+            if (stringBuilder.length() != 1) stringBuilder.append(",");
+            Matcher m = p.matcher("" + value);
+            if (value instanceof String && !m.find()) {
+                stringBuilder.append("\"").append(value).append("\"");
+            } else if (value instanceof com.github.mc1arke.sonarqube.plugin.almclient.github.v4.InputObject) {
+                stringBuilder.append(((InputObject<?>) value).getMessage());
+            } else {
+                stringBuilder.append(value);
+            }
+        }
+        stringBuilder.append("]");
+        return stringBuilder.toString();
+    }
+
+}

--- a/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
+++ b/src/test/java/com/github/mc1arke/sonarqube/plugin/almclient/github/v4/GraphqlGithubClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 Michael Clarke
+ * Copyright (C) 2020-2024 Michael Clarke
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -31,7 +31,6 @@ import io.aexp.nodes.graphql.Arguments;
 import io.aexp.nodes.graphql.GraphQLRequestEntity;
 import io.aexp.nodes.graphql.GraphQLResponseEntity;
 import io.aexp.nodes.graphql.GraphQLTemplate;
-import io.aexp.nodes.graphql.InputObject;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.sonar.api.issue.Issue;


### PR DESCRIPTION
The Github Cloud API now returns an error about the input message being malformed, seemingly due to a change in how new lines in messages are being handled. As the use of blockquotes around multi-line messages appears to continue to work, the analysis messages are being wrapped in blockquotes rather than double-quotes where they contain newline characters. This requires an interim measure of cloning the InputObject class from the nodes library to alter the String comparison and wrapping since the library is no longer maintained.